### PR TITLE
Look for NSCalibratedRGBColorSpace when code-generating color lists

### DIFF
--- a/colordump/CDColorListDumper.m
+++ b/colordump/CDColorListDumper.m
@@ -33,8 +33,8 @@
     
     for (NSString *key in colorList.allKeys) {
         NSColor *color = [colorList colorWithKey:key];
-        if (![color.colorSpaceName isEqualToString:NSDeviceRGBColorSpace]) {
-            printf("Color %s isn't device RGB. Skipping.", [key UTF8String]);
+        if (![color.colorSpaceName isEqualToString:NSCalibratedRGBColorSpace]) {
+            printf("Color %s isn't generic calibrated RGB. Skipping.", [key UTF8String]);
             continue;
         }
         


### PR DESCRIPTION
Expect NSCalibratedRGBColorSpace from color lists, as its what `+[UIColor colorWithRed:green:blue:alpha:]` uses. Without this change, you end up with slightly different colors depending on if you're using the generated code or drag-and-dropping colors from the color list in IB.

@puls 
