### PR TITLE
replace disallowed characters '@' and '-' in method names

### DIFF
--- a/Shared/CGUCodeGenTool.m
+++ b/Shared/CGUCodeGenTool.m
@@ -174,6 +174,8 @@
     }
     [mutableKey replaceOccurrencesOfString:@" " withString:@"" options:0 range:NSMakeRange(0, mutableKey.length)];
     [mutableKey replaceOccurrencesOfString:@"~" withString:@"" options:0 range:NSMakeRange(0, mutableKey.length)];
+    [mutableKey replaceOccurrencesOfString:@"@" withString:@"" options:0 range:NSMakeRange(0, mutableKey.length)];
+    [mutableKey replaceOccurrencesOfString:@"-" withString:@"_" options:0 range:NSMakeRange(0, mutableKey.length)];
     return [mutableKey copy];
 }
 


### PR DESCRIPTION
I had some issues with the generated .h and .m files as the method names contained @ and - which are illegal in method names. So these characters are now replaced when generating files.

I guess it would make sense to generalize the replacement of characters not allowed in method names. Maybe some NSCharacter​Set love?
