### PR TITLE
Add Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Options:
 <dt><code>&lt;paths></code></dt><dd>Input files; this and/or `-f` are required.</dd>
 </dl>
 
+## Installation
+
+1. Download the source code.
+2. Build the 3 tools in Xcode.
+3. Move binaries to folder `/usr/local/bin`
+
 ## Contributing
 
 We're glad you're interested in codegenutils, and we'd love to see where you take it. When you have a change you'd like to see in the master repository, [send a pull request](https://github.com/square/objc-codegenutils/pulls).


### PR DESCRIPTION
Hi,

I remember reading about this set of tools a while ago and now that I use more and more Storyboards, I wanted to set this up and was hopping for a installation paragraph in the `README`. Hopefully it will help others.

Note 1: Could also simplify it and add the move binaries directly into the scheme if needed and path correct (`/usr/local/bin`).
Note 2: what about a one liner script like a `install.sh` via curl downloading a binaries contained in Github releases?
